### PR TITLE
Add path removals for clean

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -4,7 +4,7 @@ import { data } from '@serverless/cloud'
 
 import { isSecondary } from './indexes'
 import { Exact } from './query'
-import { Labels } from './type-helpers'
+import { Labels, KeyPath } from './type-helpers'
 
 
 function prune(model: Model<any>): any {
@@ -14,24 +14,11 @@ function prune(model: Model<any>): any {
   return copy
 }
 
-/**
- *
- * Recursively remove any object keys without values,
- *
- */
-function removeEmpty(obj: Model<any>): any {
-  return Object.fromEntries(
-    Object.entries(obj)
-      .filter(([_, v]) => v !== null)
-      .map(([k, v]) => [k, v === Object(v) ? removeEmpty(v) : v])
-  )
-}
 
 /**
  *
  * Remove properties for path provided as a string seperated by full stops
- * ie model.clean(['x.y']), remove parent keys also if they have no other 
- * properties.
+ * ie model.clean(['x.y'])
  *
  */
 
@@ -47,7 +34,6 @@ function deletePropertyByPath(model: Model<any>, path: string): any {
       }
     })
     delete copy[lastKeyOfPath]
-    removeEmpty(copy)
   }
 }
 
@@ -137,7 +123,7 @@ export abstract class Model<T extends Model<T>> {
    * @param exclude Fields to be excluded.
    *
    */
-  clean<K extends keyof T>(exclude: string[] = []) {
+  clean(exclude: KeyPath<T>[] = []) {
     const cleaned = prune(this)
     exclude.forEach(key => {
       if (typeof key === 'string') {

--- a/src/test/model.test.ts
+++ b/src/test/model.test.ts
@@ -12,6 +12,7 @@ class M extends Model<M> {
   id: string
   theX: number
   y: string
+  z: object
 
   keys() {
     return [
@@ -157,16 +158,51 @@ describe('Model', () => {
     m.theX = 42
     m.y = 'WHATEVS'
     m.id = 'hola'
+    m.z = {
+      o: {
+        r: 'amigo',
+        b: {
+          s: 'siracha'
+        }
+      }
+    }
 
     m.clean().should.eql({
       id: 'hola',
       the_x: 42,
-      y: 'WHATEVS'
+      y: 'WHATEVS',
+      z: {
+        o: {
+          r: 'amigo',
+          b: {
+            s: 'siracha'
+          }
+        }
+      }
     })
 
     m.clean(['y']).should.eql({
       the_x: 42,
-      id: 'hola'
+      id: 'hola',
+      z: {
+        o: {
+          r: 'amigo',
+          b: {
+            s: 'siracha'
+          }
+        }
+      }
+    })
+
+    m.clean(['z.o.r.b.s']).should.eql({
+      the_x: 42,
+      id: 'hola',
+      y: 'WHATEVS',
+      z: {
+        o: {
+          r: 'amigo',
+        }
+      }
     })
   })
 })

--- a/src/test/model.test.ts
+++ b/src/test/model.test.ts
@@ -12,7 +12,14 @@ class M extends Model<M> {
   id: string
   theX: number
   y: string
-  z: object
+  z: {
+    o: {
+      r: string,
+      b: {
+        s: string
+      }
+    }
+  }
 
   keys() {
     return [
@@ -194,13 +201,14 @@ describe('Model', () => {
       }
     })
 
-    m.clean(['z.o.r.b.s']).should.eql({
+    m.clean(['z.o.b.s']).should.eql({
       the_x: 42,
       id: 'hola',
       y: 'WHATEVS',
       z: {
         o: {
           r: 'amigo',
+          b:{},
         }
       }
     })

--- a/src/type-helpers.ts
+++ b/src/type-helpers.ts
@@ -27,3 +27,31 @@ export type ResponseList<T> = {
   items: KeyValue<T>[],
   lastKey?: string
 }
+
+
+/**
+*
+* Types for parsing key path strings
+*
+*/
+
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...0[]]
+
+type Join<K, P> =
+K extends string | number ?
+  P extends string | number ?
+    `${K}${'' extends P ? '' : '.'}${P}`
+    : never
+  : never
+
+export type KeyPath<T, D extends number = 10> =
+[D] extends [never] ?
+  never
+  : T extends object ?
+    { [K in keyof T]-?:
+      K extends string | number ?
+        `${K}` | (KeyPath<T[K], Prev[D]> extends infer R ? Join<K, R> : never)
+        : never
+    }[keyof T]
+    : ''


### PR DESCRIPTION
I'm not an advanced user when it comes to Typescript, so not sure how best to change the types here, to enable providing the strings function with a dot-separated path:
`clean<K extends keyof T>(exclude: K[] = []) {`

I just switched the type of exclude to an array of strings so I could run the tests. 
`clean<K extends keyof T>(exclude: string[] = []) {`

Other than that all seems to work well.